### PR TITLE
Fix link tool path for MKL 2021.1.1 and newer

### DIFF
--- a/cmake/FindMKL.cmake
+++ b/cmake/FindMKL.cmake
@@ -99,7 +99,10 @@ else()
     set(MKL_INCLUDE_DIR ${MKL_ROOT_DIR}/include)
 
     # set arguments to call the MKL provided tool for linking
-    if (EXISTS "${MKL_ROOT_DIR}/bin/mkl_link_tool")
+    if (EXISTS "${MKL_ROOT_DIR}/bin/intel64/mkl_link_tool")
+      # this path is used by MKL 2021.1.1 and newer
+      set(MKL_LINK_TOOL "${MKL_ROOT_DIR}/bin/intel64/mkl_link_tool")
+    elseif (EXISTS "${MKL_ROOT_DIR}/bin/mkl_link_tool")
       # this path is used by MKL 2020.1.217 and newer
       set(MKL_LINK_TOOL "${MKL_ROOT_DIR}/bin/mkl_link_tool")
     elseif (EXISTS "${MKL_ROOT_DIR}/tools/mkl_link_tool")


### PR DESCRIPTION
MKL 2021.1.1 has moved the link tool to a new path. This pull request fixes FindMKL to support the new location.