### PR TITLE
Setting iomp5 when running on linux with icc.

### DIFF
--- a/cmake/FindMKL.cmake
+++ b/cmake/FindMKL.cmake
@@ -199,7 +199,8 @@ else()
     endif()
 
     if (MKL_USE_parallel)
-        if (UNIX AND NOT APPLE)
+      	# With icc on linux, supported values by mkl_link_tool for threading library are: iomp5|tbb
+        if (UNIX AND NOT APPLE AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
             list(APPEND MKL_LINK_TOOL_COMMAND "--openmp=gomp")
         else()
             list(APPEND MKL_LINK_TOOL_COMMAND "--threading-library=iomp5")


### PR DESCRIPTION
omp is not a supported option when using icc on linux. 
This is the output from mkl_link_tool:

```
/opt/intel/compilers_and_libraries_2019.5.281/linux/mkl/tools/mkl_link_tool -libs --mkl=11.3 --compiler=intel_c --os=lnx --arch=intel64 --linking=dynamic --parallel=yes --interface=lp64 --openmp=omp

       Intel(R) Math Kernel Library (Intel(R) MKL) Link Tool v4.7
       ==========================================================

Unknown threading library: omp. Supported values for threading library: iomp5|tbb```